### PR TITLE
Create display message on pinpad

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ A SDK do iOS pode ser encontrada [aqui](https://github.com/stone-pagamentos/sdk-
 - [stone_sdk.transaction](#transaction)
 - [stone_sdk.transactionList](#transactionlist)
 - [stone_sdk.transactionCancel](#transactioncancel)
-
+- [stone_sdk.displayMessage](#displayMessage)
 
 ## validation
 
@@ -157,5 +157,23 @@ A função `transactionCancel` é responsável pelo cancelamento da transação 
 ### Parâmetros
 
 - __idTransaction_amountTransaction_statusTransaction__: Id da transação, valor transacionado e o seu status.
+- __success__: Callback de sucesso.
+- __failure__: Callback de falha.
+
+## displayMessage
+
+Exibe uma mensagem no pinpad conectado
+
+    stone_sdk.displayMessage(deviceName, deviceMacAddress, messageToDisplay, success, failure);
+    
+### Descrição
+
+A função `displayMessage` é responsável pelo envio de uma mensagem para o display do pinpad.
+
+### Parâmetros
+
+- __deviceName__: Nome do dispositivo utilizado na conexão.
+- __deviceMacAddress__: Endereço Mac do dispotivo.
+- __messageToDisplay__: Mensagem a ser exibida no display.
 - __success__: Callback de sucesso.
 - __failure__: Callback de falha.

--- a/www/stone_sdk.js
+++ b/www/stone_sdk.js
@@ -20,4 +20,7 @@ module.exports = {
   validation: function (stoneCodeList, successCallback, errorCallback) {
     cordova.exec(successCallback, errorCallback, "StoneSDK", "validation", [stoneCodeList]);
   },
+  displayMessage: function (deviceName, deviceMacAddress, messageToDisplay, successCallback, errorCallback) {
+    cordova.exec(successCallback, errorCallback, "StoneSDK", "displayMessage", [deviceName, deviceMacAddress, messageToDisplay]);
+  },
 };


### PR DESCRIPTION
Olá @filpgame e devs da Stone,
Como vão?

Há algum tempo atrás a gente implementou algumas correções nesse repo para as aplicações feitas com Cordova.

Agora voltei a mexer no repo pois estou implementando essa tool em outro projeto super bacana de pagamento através da Stone e percebi que a SDK Android teve várias melhorias.

Este repo usa a versão 2.5.9 e a versão atual é 3.0.4, mas os métodos funcionam normalmente até hoje e quando tentei atualizar para a versão 3.0.4 do SDK o build não rodou, acredito que outros métodos alteraram entre as versões.

O que estou sentindo falta é o método de DisplayMessageProvider que está na documentação e "implementado" na SDK Stone Android.

O que tem acontecido aqui nos pinpads é que as mensagens que aparecem são sempre a ultima mensagem enviada das transações, por exemplo: "insira o cartão", "transação aprovada" entre outras.

Com isso o usuário fica confuso se ele deve prosseguir e ou qual ação tomar em determinados casos, como quando ocorre erro e não há retorno para o display.

Fiz alguns testes tentando utilizar este provider mas não obtive sucesso na implementação desta funcionalidade, vocês poderiam me ajudar por favor?